### PR TITLE
fix: add fully-qualified function names for Git-Status

### DIFF
--- a/source/public/Show-PoshGitStatus.ps1
+++ b/source/public/Show-PoshGitStatus.ps1
@@ -51,7 +51,7 @@ function Show-PoshGitStatus {
     # The end block will be turned into a closure and a TerminalBlock will be created
     end {
         if (Get-Module posh-git) {
-            Write-GitStatus (Get-GitStatus)
+            posh-git\Write-GitStatus (posh-git\Get-GitStatus)
         }
     }
 }


### PR DESCRIPTION
The modules `posh-git` and `PowerGit` both have a function (or alias to a function) named `Get-GitStatus`.   When calling `Get-GitStatus`, to be used in the prompt, ensure we call `posh-git\Get-GitStatus`